### PR TITLE
Correctly serialize exception info

### DIFF
--- a/src/Seq.Input.HealthCheck/HealthCheckReporter.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckReporter.cs
@@ -7,11 +7,7 @@ namespace Seq.Input.HealthCheck
     class HealthCheckReporter
     {
         readonly TextWriter _output;
-
-        readonly JsonSerializer _serializer = JsonSerializer.Create(
-            new JsonSerializerSettings {
-                DateFormatHandling = DateFormatHandling.IsoDateFormat
-            });
+        readonly JsonSerializer _serializer = JsonSerializer.Create();
 
         public HealthCheckReporter(TextWriter output)
         {

--- a/src/Seq.Input.HealthCheck/HealthCheckResult.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckResult.cs
@@ -10,7 +10,7 @@ namespace Seq.Input.HealthCheck
         public DateTime UtcTimestamp { get; }
 
         [JsonProperty("@x", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public Exception Exception { get; }
+        public string Exception { get; }
 
         [JsonProperty("@mt")]
         public string MessageTemplate { get; } =
@@ -62,7 +62,7 @@ namespace Seq.Input.HealthCheck
             ContentType = contentType;
             ContentLength = contentLength;
             InitialContent = initialContent;
-            Exception = exception;
+            Exception = exception?.ToString();
         }
     }
 }

--- a/src/Seq.Input.HealthCheck/HealthCheckTask.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckTask.cs
@@ -29,12 +29,14 @@ namespace Seq.Input.HealthCheck
             {
                 while (!cancel.IsCancellationRequested)
                 {
-
                     var result = await healthCheck.CheckNow(cancel);
                     reporter.Report(result);
 
                     if (result.Elapsed < interval.TotalMilliseconds)
-                        await Task.Delay((int)(interval.TotalMilliseconds - result.Elapsed), cancel);
+                    {
+                        var delay = (int) (interval.TotalMilliseconds - result.Elapsed);
+                        await Task.Delay(delay, cancel);
+                    }
                 }
             }
             catch (OperationCanceledException)

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -15,7 +15,7 @@ namespace Seq.Input.HealthCheck
         readonly HttpClient _httpClient;
         readonly byte[] _buffer = new byte[2048];
 
-        static UTF8Encoding _forgivingEncoding = new UTF8Encoding(false, false);
+        static readonly UTF8Encoding ForgivingEncoding = new UTF8Encoding(false, false);
 
         public HttpHealthCheck(string title, string targetUrl)
         {
@@ -74,7 +74,7 @@ namespace Seq.Input.HealthCheck
         async Task<string> DownloadContent(Stream body)
         {
             var read = await body.ReadAsync(_buffer, 0, _buffer.Length);
-            var initial = _forgivingEncoding.GetString(_buffer, 0, Math.Min(read, 16));
+            var initial = ForgivingEncoding.GetString(_buffer, 0, Math.Min(read, 16));
             while (read > 0)
             {
                 read = await body.ReadAsync(_buffer, 0, _buffer.Length);


### PR DESCRIPTION
The `@x` CLEF field must be a string.