### PR TITLE
More defensive connection and redirect handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Periodically GET an HTTP resource and write response metrics to Seq. These can t
 1. The app requires Seq 5.1 or newer
 2. Navigate to _Settings_ > _Apps_ and select _Install from NuGet_
 3. Install the app with package id _Seq.Input.HealthCheck_
-4. Back on the _Apps_ screen, choose _Start new instance_
+4. Back on the _Apps_ screen, choose _Add Instance_
 5. Enter a title for the health check; events raised by the health check will be tagged with this
 6. Enter a URL to probe
    - the URL must respond to `GET` requests

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -21,7 +21,9 @@ namespace Seq.Input.HealthCheck
         {
             _title = title ?? throw new ArgumentNullException(nameof(title));
             _targetUrl = targetUrl ?? throw new ArgumentNullException(nameof(targetUrl));
-            _httpClient = new HttpClient();
+
+            var handler = new HttpClientHandler {AllowAutoRedirect = false};
+            _httpClient = new HttpClient(handler);
             _httpClient.DefaultRequestHeaders.Connection.Add("Close");
         }
 

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -22,6 +22,7 @@ namespace Seq.Input.HealthCheck
             _title = title ?? throw new ArgumentNullException(nameof(title));
             _targetUrl = targetUrl ?? throw new ArgumentNullException(nameof(targetUrl));
             _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.Connection.Add("Close");
         }
 
         public async Task<HealthCheckResult> CheckNow(CancellationToken cancel)


### PR DESCRIPTION
Two maybe-slightly-contentious changes:

 - Always open a new connection for every heath check; this ensures DNS changes are observed and more connection establishment problems are caught
 - Stop following redirects and instead report 3xx status codes (these will be regarded as failures as they're not in 2xx - whether this is appropriate or not depends on whether other clients of the resource can follow redirects, so failing on 3xx is the most conservative choice)