### PR TITLE
Adds a net4.6.2 target to avoid assembly loading/binding issues on .NET 4.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Periodically GET an HTTP resource and write response metrics to Seq. These can t
 
 ### Getting started
 
-1. The app requires Seq 5.1 or newer; current versions **require .NET 4.7.2 on the Seq server machine**, if running on Windows
+1. The app requires Seq 5.1 or newer
 2. Navigate to _Settings_ > _Apps_ and select _Install from NuGet_
 3. Install the app with package id _Seq.Input.HealthCheck_
 4. Back on the _Apps_ screen, choose _Add Instance_

--- a/src/Seq.Input.HealthCheck/Seq.Input.HealthCheck.csproj
+++ b/src/Seq.Input.HealthCheck/Seq.Input.HealthCheck.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net4.6.2</TargetFrameworks>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Description>Seq Health Check: periodically GET an HTTP resource and publish response metrics to Seq.</Description>
     <Authors>Datalust and Contributors</Authors>
@@ -17,7 +17,8 @@
 
   <ItemGroup>
     <PackageReference Include="newtonsoft.json" Version="12.0.1" />
-    <PackageReference Include="Seq.Apps" Version="5.1.0-*" />
+    <PackageReference Include="Seq.Apps" Version="5.1.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
See: https://github.com/datalust/seq-tickets/issues/820