### PR TITLE
Option to append a unique cache-busting parameter to target URLs

### DIFF
--- a/seq-input-healthcheck.sln.DotSettings
+++ b/seq-input-healthcheck.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=lepv/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -50,13 +50,12 @@ namespace Seq.Input.HealthCheck
         public string DataExtractionExpression { get; set; }
 
         [SeqAppSetting(
-            DisplayName = "Append unique identifier",
+            DisplayName = "Bypass HTTP caching",
             IsOptional = true,
-            HelpText = "If selected, a unique `" + HttpHealthCheck.HealthCheckIdUrlParameterName  + "` query " +
-                       "string parameter will be added to the URL for each request, in order to disable any " +
-                       "intermediary HTTP caching. The parameter value will be logged in the resulting health " +
-                       "check event as `HealthCheckId` to support correlation.")]
-        public bool AppendUniqueIdentifier { get; set; }
+            HelpText = "If selected, the unique probe id will be appended to the target URL query string as " +
+                       "`" + HttpHealthCheck.ProbeIdParameterName  + "`, in order to disable any " +
+                       "intermediary HTTP caching. The `Cache-Control: nocache` header will also be sent.")]
+        public bool BypassHttpCaching { get; set; }
 
         public void Start(TextWriter inputWriter)
         {
@@ -75,7 +74,7 @@ namespace Seq.Input.HealthCheck
                     App.Title,
                     targetUrl,
                     extractor,
-                    AppendUniqueIdentifier);
+                    BypassHttpCaching);
 
                 _healthCheckTasks.Add(new HealthCheckTask(
                     healthCheck,

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -54,7 +54,7 @@ namespace Seq.Input.HealthCheck
             IsOptional = true,
             HelpText = "If selected, the unique probe id will be appended to the target URL query string as " +
                        "`" + HttpHealthCheck.ProbeIdParameterName  + "`, in order to disable any " +
-                       "intermediary HTTP caching. The `Cache-Control: no-cache` header will also be sent.")]
+                       "intermediary HTTP caching. The `Cache-Control: no-store` header will also be sent.")]
         public bool BypassHttpCaching { get; set; }
 
         public void Start(TextWriter inputWriter)

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
@@ -35,6 +49,15 @@ namespace Seq.Input.HealthCheck
                        "response. The response must be UTF-8 `application/json` for this to be applied.")]
         public string DataExtractionExpression { get; set; }
 
+        [SeqAppSetting(
+            DisplayName = "Append unique identifier",
+            IsOptional = true,
+            HelpText = "If selected, a unique `" + HttpHealthCheck.HealthCheckIdUrlParameterName  + "` query " +
+                       "string parameter will be added to the URL for each request, in order to disable any " +
+                       "intermediary HTTP caching. The parameter value will be logged in the resulting health " +
+                       "check event as `HealthCheckId` to support correlation.")]
+        public bool AppendUniqueIdentifier { get; set; }
+
         public void Start(TextWriter inputWriter)
         {
             _httpClient = HttpHealthCheckClient.Create();
@@ -51,7 +74,8 @@ namespace Seq.Input.HealthCheck
                     _httpClient,
                     App.Title,
                     targetUrl,
-                    extractor);
+                    extractor,
+                    AppendUniqueIdentifier);
 
                 _healthCheckTasks.Add(new HealthCheckTask(
                     healthCheck,

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -54,7 +54,7 @@ namespace Seq.Input.HealthCheck
             IsOptional = true,
             HelpText = "If selected, the unique probe id will be appended to the target URL query string as " +
                        "`" + HttpHealthCheck.ProbeIdParameterName  + "`, in order to disable any " +
-                       "intermediary HTTP caching. The `Cache-Control: nocache` header will also be sent.")]
+                       "intermediary HTTP caching. The `Cache-Control: no-cache` header will also be sent.")]
         public bool BypassHttpCaching { get; set; }
 
         public void Start(TextWriter inputWriter)

--- a/src/Seq.Input.HealthCheck/HealthCheckReporter.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckReporter.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.IO;
 using Newtonsoft.Json;
 

--- a/src/Seq.Input.HealthCheck/HealthCheckResult.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckResult.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -38,6 +52,9 @@ namespace Seq.Input.HealthCheck
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public JToken Data { get; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string HealthCheckId { get; }
+
         public HealthCheckResult(
             DateTime utcTimestamp,
             string healthCheckTitle,
@@ -51,7 +68,8 @@ namespace Seq.Input.HealthCheck
             long? contentLength,
             string initialContent,
             Exception exception,
-            JToken data)
+            JToken data,
+            string healthCheckId)
         {
             if (utcTimestamp.Kind != DateTimeKind.Utc)
                 throw new ArgumentException("The timestamp must be UTC.", nameof(utcTimestamp));
@@ -71,6 +89,7 @@ namespace Seq.Input.HealthCheck
             InitialContent = initialContent;
             Exception = exception?.ToString();
             Data = data;
+            HealthCheckId = healthCheckId;
         }
     }
 }

--- a/src/Seq.Input.HealthCheck/HealthCheckResult.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckResult.cs
@@ -45,6 +45,7 @@ namespace Seq.Input.HealthCheck
         public int? StatusCode { get; }
         public string ContentType { get; }
         public long? ContentLength { get; }
+        public string ProbeId { get; }
 
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public string InitialContent { get; }
@@ -52,15 +53,13 @@ namespace Seq.Input.HealthCheck
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public JToken Data { get; }
 
-        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public string HealthCheckId { get; }
-
         public HealthCheckResult(
             DateTime utcTimestamp,
             string healthCheckTitle,
             string method,
             string targetUrl,            
             string outcome,
+            string probeId,
             string level,
             double elapsed,
             int? statusCode,
@@ -68,8 +67,7 @@ namespace Seq.Input.HealthCheck
             long? contentLength,
             string initialContent,
             Exception exception,
-            JToken data,
-            string healthCheckId)
+            JToken data)
         {
             if (utcTimestamp.Kind != DateTimeKind.Utc)
                 throw new ArgumentException("The timestamp must be UTC.", nameof(utcTimestamp));
@@ -80,6 +78,7 @@ namespace Seq.Input.HealthCheck
             Method = method ?? throw new ArgumentNullException(nameof(method));
             TargetUrl = targetUrl ?? throw new ArgumentNullException(nameof(targetUrl));
             Outcome = outcome ?? throw new ArgumentNullException(nameof(outcome));
+            ProbeId = probeId ?? throw new ArgumentNullException(nameof(probeId));
 
             Level = level;
             Elapsed = elapsed;
@@ -89,7 +88,6 @@ namespace Seq.Input.HealthCheck
             InitialContent = initialContent;
             Exception = exception?.ToString();
             Data = data;
-            HealthCheckId = healthCheckId;
         }
     }
 }

--- a/src/Seq.Input.HealthCheck/HealthCheckTask.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckTask.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -74,7 +74,7 @@ namespace Seq.Input.HealthCheck
                 request.Headers.Add("X-Correlation-ID", probeId);
 
                 if (_bypassHttpCaching)
-                    request.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true };
+                    request.Headers.CacheControl = new CacheControlHeaderValue { NoStore = true };
 
                 var response = await _httpClient.SendAsync(request, cancel);
                 

--- a/src/Seq.Input.HealthCheck/JsonDataExtractor.cs
+++ b/src/Seq.Input.HealthCheck/JsonDataExtractor.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -11,7 +25,7 @@ namespace Seq.Input.HealthCheck
 {
     public class JsonDataExtractor
     {
-        static JsonValueFormatter ValueFormatter = new JsonValueFormatter("$type");
+        static readonly JsonValueFormatter ValueFormatter = new JsonValueFormatter("$type");
         static readonly JsonSerializer Serializer = JsonSerializer.Create(new JsonSerializerSettings
         {
             DateParseHandling = DateParseHandling.None

--- a/src/Seq.Input.HealthCheck/Properties/AssemblyInfo.cs
+++ b/src/Seq.Input.HealthCheck/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Seq.Input.HealthCheck.Tests")]

--- a/src/Seq.Input.HealthCheck/Seq.Input.HealthCheck.csproj
+++ b/src/Seq.Input.HealthCheck/Seq.Input.HealthCheck.csproj
@@ -16,6 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
     <PackageReference Include="newtonsoft.json" Version="12.0.1" />
     <PackageReference Include="Seq.Apps" Version="5.1.0" />
     <PackageReference Include="Serilog" Version="2.8.0" />

--- a/src/Seq.Input.HealthCheck/Util/Nonce.cs
+++ b/src/Seq.Input.HealthCheck/Util/Nonce.cs
@@ -1,0 +1,53 @@
+﻿// Copyright 2019 Datalust and contributors. 
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Seq.Input.HealthCheck.Util
+{
+    static class Nonce
+    {
+        public static string Generate(int chars)
+        {
+            if (chars < 0) throw new ArgumentOutOfRangeException(nameof(chars));
+            return new string(GenerateChars(chars).ToArray());
+        }
+
+        static IEnumerable<char> GenerateChars(int count)
+        {
+            var rem = count;
+            var buf = new byte[128];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                while (rem > 0)
+                {
+                    rng.GetBytes(buf);
+                    var b64 = Convert.ToBase64String(buf);
+                    for (var i = 0; i < b64.Length && rem > 0; ++i)
+                    {
+                        var c = b64[i];
+                        if (char.IsLetterOrDigit(c))
+                        {
+                            yield return c;
+                            rem--;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Seq.Input.HealthCheck/Util/UrlHelper.cs
+++ b/src/Seq.Input.HealthCheck/Util/UrlHelper.cs
@@ -12,18 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Net.Http;
+using System;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.WebUtilities;
 
-namespace Seq.Input.HealthCheck
+namespace Seq.Input.HealthCheck.Util
 {
-    public static class HttpHealthCheckClient
+    static class UrlHelper
     {
-        public static HttpClient Create()
+        public static string AppendParameter(string targetUrl, string name, string value)
         {
-            var handler = new HttpClientHandler { AllowAutoRedirect = false };
-            var httpClient = new HttpClient(handler);
-            httpClient.DefaultRequestHeaders.Connection.Add("Close");
-            return httpClient;
+            if (targetUrl == null) throw new ArgumentNullException(nameof(targetUrl));
+            if (name == null) throw new ArgumentNullException(nameof(name));
+            if (value == null) throw new ArgumentNullException(nameof(value));
+
+            return QueryHelpers.AddQueryString(targetUrl, new Dictionary<string, string>
+            {
+                [name] = value
+            });
         }
     }
 }

--- a/test/Seq.Input.HealthCheck.Tests/Util/NonceTests.cs
+++ b/test/Seq.Input.HealthCheck.Tests/Util/NonceTests.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Seq.Input.HealthCheck.Util;
+using Xunit;
+
+namespace Seq.Input.HealthCheck.Tests.Util
+{
+    public class NonceTests
+    {
+        public static IEnumerable<object[]> CharacterCounts = Enumerable.Range(0, 100).Select(n => new [] { (object)n });
+
+        [Theory]
+        [MemberData(nameof(CharacterCounts))]
+        public void NonceGeneratesCorrectCharacterCount(int count)
+        {
+            var nonce = Nonce.Generate(count);
+            Assert.Equal(count, nonce.Length);
+        }
+
+        [Fact]
+        public void NonceIsSufficientlyRandom()
+        {
+            var a = Nonce.Generate(8);
+
+            // Not entirely scientific ;-)
+            for (var i = 0; i < 100; ++i)
+            {
+                var b = Nonce.Generate(8);
+                Assert.NotEqual(a, b);
+            }
+        }
+    }
+}

--- a/test/Seq.Input.HealthCheck.Tests/Util/UrlHelperTests.cs
+++ b/test/Seq.Input.HealthCheck.Tests/Util/UrlHelperTests.cs
@@ -1,0 +1,20 @@
+﻿using Seq.Input.HealthCheck.Util;
+using Xunit;
+
+namespace Seq.Input.HealthCheck.Tests.Util
+{
+    public class UrlHelperTests
+    {
+        [Theory]
+        [InlineData("https://example.com", "https://example.com?q=42")]
+        [InlineData("https://example.com/p", "https://example.com/p?q=42")]
+        [InlineData("https://example.com/p/", "https://example.com/p/?q=42")]
+        [InlineData("https://example.com?a", "https://example.com?a&q=42")]
+        [InlineData("https://example.com?a=1", "https://example.com?a=1&q=42")]
+        public void ParametersAreAppendedCorrectly(string initial, string expected)
+        {
+            var actual = UrlHelper.AppendParameter(initial, "q", "42");
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
This option should cause health check requests to bypass any caching infrastructure between the checker and application.

The PR introduces a unique "probe id" for each outbound request; this will always be sent in `X-Correlation-ID`, and logged as `ProbeId` in the health check results.

If _Bypass HTTP caching_ is selected, the probe id will be appended to the target URL as `__probe`. We'll additionally set `Cache-Control: no-store` header - which most caches should respect :-)