### PR TITLE
Keep TargetUrl as the original/raw target URL, separately log the probed URL

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -24,10 +24,10 @@ foreach ($src in ls src/*) {
     echo "build: Packaging project in $src"
 
     if ($suffix) {
-        & dotnet publish -c Release -o ./obj/publish --version-suffix=$suffix --self-contained
+        & dotnet publish -c Release -o ./obj/publish --version-suffix=$suffix
         & dotnet pack -c Release -o ..\..\artifacts --no-build --version-suffix=$suffix
     } else {
-        & dotnet publish -c Release -o ./obj/publish --self-contained
+        & dotnet publish -c Release -o ./obj/publish
         & dotnet pack -c Release -o ..\..\artifacts --no-build
     }
     if($LASTEXITCODE -ne 0) { exit 1 }    

--- a/Build.ps1
+++ b/Build.ps1
@@ -24,10 +24,10 @@ foreach ($src in ls src/*) {
     echo "build: Packaging project in $src"
 
     if ($suffix) {
-        & dotnet publish -c Release -o ./obj/publish --version-suffix=$suffix
+        & dotnet publish -c Release -o ./obj/publish --version-suffix=$suffix --self-contained
         & dotnet pack -c Release -o ..\..\artifacts --no-build --version-suffix=$suffix
     } else {
-        & dotnet publish -c Release -o ./obj/publish
+        & dotnet publish -c Release -o ./obj/publish --self-contained
         & dotnet pack -c Release -o ..\..\artifacts --no-build
     }
     if($LASTEXITCODE -ne 0) { exit 1 }    

--- a/src/Seq.Input.HealthCheck/HealthCheckResult.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckResult.cs
@@ -53,6 +53,9 @@ namespace Seq.Input.HealthCheck
         [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
         public JToken Data { get; }
 
+        [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ProbedUrl { get; }
+
         public HealthCheckResult(
             DateTime utcTimestamp,
             string healthCheckTitle,
@@ -67,7 +70,8 @@ namespace Seq.Input.HealthCheck
             long? contentLength,
             string initialContent,
             Exception exception,
-            JToken data)
+            JToken data,
+            string probedUrl)
         {
             if (utcTimestamp.Kind != DateTimeKind.Utc)
                 throw new ArgumentException("The timestamp must be UTC.", nameof(utcTimestamp));
@@ -88,6 +92,7 @@ namespace Seq.Input.HealthCheck
             InitialContent = initialContent;
             Exception = exception?.ToString();
             Data = data;
+            ProbedUrl = probedUrl;
         }
     }
 }

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -61,7 +61,7 @@ namespace Seq.Input.HealthCheck
             JToken data = null;
 
             var probeId = Nonce.Generate(12);
-            var targetUrl = _bypassHttpCaching ?
+            var probedUrl = _bypassHttpCaching ?
                 UrlHelper.AppendParameter(_targetUrl, ProbeIdParameterName, probeId) :
                 _targetUrl;
 
@@ -70,7 +70,7 @@ namespace Seq.Input.HealthCheck
 
             try
             {
-                var request = new HttpRequestMessage(HttpMethod.Get, targetUrl);
+                var request = new HttpRequestMessage(HttpMethod.Get, probedUrl);
                 request.Headers.Add("X-Correlation-ID", probeId);
 
                 if (_bypassHttpCaching)
@@ -103,7 +103,7 @@ namespace Seq.Input.HealthCheck
                 utcTimestamp,
                 _title,
                 "GET",
-                targetUrl,
+                _targetUrl,
                 outcome,
                 probeId,
                 level,
@@ -113,7 +113,8 @@ namespace Seq.Input.HealthCheck
                 contentLength,
                 initialContent,
                 exception,
-                data);
+                data,
+                _targetUrl == probedUrl ? null : probedUrl);
         }
 
         // Either initial content, or extracted data


### PR DESCRIPTION
Lets `group by TargetUrl` keep working, even if cache-busting params are added.