### PR TITLE
Adding optional authentication headers to GET request & config

### DIFF
--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -34,6 +34,10 @@ namespace Seq.Input.HealthCheck
             InputType = SettingInputType.LongText)]
         public string TargetUrl { get; set; }
 
+        [SeqAppSetting(InputType = SettingInputType.Password, IsOptional = true, DisplayName = "Authentication Header",
+            HelpText = "An optional `Name: Value` header, stored as sensitive data, for authentication purposes.")]
+        public string AuthenticationHeader { get; set; }
+
         [SeqAppSetting(
             DisplayName = "Interval (seconds)",
             IsOptional = true,
@@ -73,6 +77,7 @@ namespace Seq.Input.HealthCheck
                     _httpClient,
                     App.Title,
                     targetUrl,
+                    AuthenticationHeader,
                     extractor,
                     BypassHttpCaching);
 

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -37,6 +37,22 @@ namespace Seq.Input.HealthCheck
         [SeqAppSetting(InputType = SettingInputType.Password, IsOptional = true, DisplayName = "Authentication Header",
             HelpText = "An optional `Name: Value` header, stored as sensitive data, for authentication purposes.")]
         public string AuthenticationHeader { get; set; }
+        
+        [SeqAppSetting(InputType = SettingInputType.LongText,
+            IsOptional = true,
+            DisplayName = "Additional Header",
+            HelpText = "Optional headers sent to each URL in format of `Attribute: Value`.\n" + 
+                       "Headers always need a value, attributes cannot contain spaces, duplicate attributes will be " +
+                       "overwritten in order of appearance.")]
+        public string AdditionalHeader { get; set; }
+        
+        [SeqAppSetting(
+            DisplayName = "Bypass HTTP caching",
+            IsOptional = true,
+            HelpText = "If selected, the unique probe id will be appended to the target URL query string as " +
+                "`" + HttpHealthCheck.ProbeIdParameterName  + "`, in order to disable any " +
+                "intermediary HTTP caching. The `Cache-Control: no-store` header will also be sent.")]
+        public bool BypassHttpCaching { get; set; }
 
         [SeqAppSetting(
             DisplayName = "Interval (seconds)",
@@ -53,13 +69,7 @@ namespace Seq.Input.HealthCheck
                        "response. The response must be UTF-8 `application/json` for this to be applied.")]
         public string DataExtractionExpression { get; set; }
 
-        [SeqAppSetting(
-            DisplayName = "Bypass HTTP caching",
-            IsOptional = true,
-            HelpText = "If selected, the unique probe id will be appended to the target URL query string as " +
-                       "`" + HttpHealthCheck.ProbeIdParameterName  + "`, in order to disable any " +
-                       "intermediary HTTP caching. The `Cache-Control: no-store` header will also be sent.")]
-        public bool BypassHttpCaching { get; set; }
+
 
         public void Start(TextWriter inputWriter)
         {
@@ -78,6 +88,7 @@ namespace Seq.Input.HealthCheck
                     App.Title,
                     targetUrl,
                     AuthenticationHeader,
+                    AdditionalHeader,
                     extractor,
                     BypassHttpCaching);
 

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using Seq.Apps;
+using Seq.Input.HealthCheck.Util;
 
 namespace Seq.Input.HealthCheck
 {
@@ -38,13 +39,9 @@ namespace Seq.Input.HealthCheck
             HelpText = "An optional `Name: Value` header, stored as sensitive data, for authentication purposes.")]
         public string AuthenticationHeader { get; set; }
         
-        [SeqAppSetting(InputType = SettingInputType.LongText,
-            IsOptional = true,
-            DisplayName = "Additional Header",
-            HelpText = "Optional headers sent to each URL in format of `Attribute: Value`.\n" + 
-                       "Headers always need a value, attributes cannot contain spaces, duplicate attributes will be " +
-                       "overwritten in order of appearance.")]
-        public string AdditionalHeader { get; set; }
+        [SeqAppSetting(InputType = SettingInputType.LongText, IsOptional = true, DisplayName = "Other Headers",
+            HelpText = "Additional headers to send with the request, one per line in `Name: Value` format.")]
+        public string OtherHeaders { get; set; }
         
         [SeqAppSetting(
             DisplayName = "Bypass HTTP caching",
@@ -87,8 +84,7 @@ namespace Seq.Input.HealthCheck
                     _httpClient,
                     App.Title,
                     targetUrl,
-                    AuthenticationHeader,
-                    AdditionalHeader,
+                    HeaderSettingFormat.FromSettings(AuthenticationHeader, OtherHeaders),
                     extractor,
                     BypassHttpCaching);
 

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -30,8 +30,7 @@ namespace Seq.Input.HealthCheck
     {
         readonly string _title;
         readonly string _targetUrl;
-        readonly string _authenticationHeaderValue;
-        readonly string _optionalHeader;
+        readonly List<(string, string)> _headers;
         readonly JsonDataExtractor _extractor;
         readonly bool _bypassHttpCaching;
         readonly HttpClient _httpClient;
@@ -43,32 +42,16 @@ namespace Seq.Input.HealthCheck
         const int InitialContentChars = 16;
         const string OutcomeSucceeded = "succeeded", OutcomeFailed = "failed";
 
-        public HttpHealthCheck(HttpClient httpClient, string title, string targetUrl, string authenticationHeaderValue, string optionalHeader, JsonDataExtractor extractor, bool bypassHttpCaching)
+        public HttpHealthCheck(HttpClient httpClient, string title, string targetUrl,  List<(string, string)> headers, JsonDataExtractor extractor, bool bypassHttpCaching)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _title = title ?? throw new ArgumentNullException(nameof(title));
             _targetUrl = targetUrl ?? throw new ArgumentNullException(nameof(targetUrl));
-            _authenticationHeaderValue = authenticationHeaderValue;
-            _optionalHeader = optionalHeader;
+            _headers = headers;
             _extractor = extractor;
             _bypassHttpCaching = bypassHttpCaching;
         }
-
-        static void AddOrOverwriteHeader(HttpRequestMessage request, string attribute, string value)
-        {
-            // opportunistic abort: header values cannot be empty (https://datatracker.ietf.org/doc/html/rfc7230#section-3.2)
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                return;
-            }
-            // the api does not allow overwriting, therefore removal has to happen first.
-            if (request.Headers.Contains(attribute))
-            {
-                request.Headers.Remove(attribute);
-            }
-            request.Headers.Add(attribute, value);
-        }
-
+        
         public async Task<HealthCheckResult> CheckNow(CancellationToken cancel)
         {
             string outcome;
@@ -92,24 +75,17 @@ namespace Seq.Input.HealthCheck
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, probedUrl);
                 request.Headers.Add("X-Correlation-ID", probeId);
-                if(_optionalHeader != null) {
-                    var optionalHeaders = _optionalHeader
-                        .Split(new [] {'\n'}, StringSplitOptions.RemoveEmptyEntries)
-                        .Select(line => line
-                            .Split(new [] {':'}, 1, StringSplitOptions.RemoveEmptyEntries)
-                            .Select(x => x.Trim())
-                            .ToArray())
-                        .Where(keyValuePair => keyValuePair.Length == 2)
-                        .ToArray();
-                    foreach (var optionalHeader in optionalHeaders)
-                    {
-                        AddOrOverwriteHeader(request, optionalHeader[0], optionalHeader[1]);
-                    }
-                }
-                if (_authenticationHeaderValue != null)
+                if (_headers != null)
                 {
-                    //  will explicitly overwrite Authorization if prior defined in optional headers
-                    AddOrOverwriteHeader(request, "Authorization", _authenticationHeaderValue);
+                    foreach (var (name, value) in _headers)
+                    {
+                        // the api does not allow overwriting, therefore removal has to happen first.
+                        if (request.Headers.Contains(name))
+                        {
+                            request.Headers.Remove(name);
+                        }
+                        request.Headers.Add(name, value);
+                    }
                 }
 
                 if (_bypassHttpCaching)

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -29,6 +29,7 @@ namespace Seq.Input.HealthCheck
     {
         readonly string _title;
         readonly string _targetUrl;
+        readonly string _authenticationHeaderValue;
         readonly JsonDataExtractor _extractor;
         readonly bool _bypassHttpCaching;
         readonly HttpClient _httpClient;
@@ -40,11 +41,12 @@ namespace Seq.Input.HealthCheck
         const int InitialContentChars = 16;
         const string OutcomeSucceeded = "succeeded", OutcomeFailed = "failed";
 
-        public HttpHealthCheck(HttpClient httpClient, string title, string targetUrl, JsonDataExtractor extractor, bool bypassHttpCaching)
+        public HttpHealthCheck(HttpClient httpClient, string title, string targetUrl, string authenticationHeaderValue, JsonDataExtractor extractor, bool bypassHttpCaching)
         {
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             _title = title ?? throw new ArgumentNullException(nameof(title));
             _targetUrl = targetUrl ?? throw new ArgumentNullException(nameof(targetUrl));
+            _authenticationHeaderValue = authenticationHeaderValue;
             _extractor = extractor;
             _bypassHttpCaching = bypassHttpCaching;
         }
@@ -72,6 +74,10 @@ namespace Seq.Input.HealthCheck
             {
                 var request = new HttpRequestMessage(HttpMethod.Get, probedUrl);
                 request.Headers.Add("X-Correlation-ID", probeId);
+                if (_authenticationHeaderValue != null)
+                {
+                    request.Headers.Add("Authorization", _authenticationHeaderValue);
+                }
 
                 if (_bypassHttpCaching)
                     request.Headers.CacheControl = new CacheControlHeaderValue { NoStore = true };

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -94,8 +94,11 @@ namespace Seq.Input.HealthCheck
                 request.Headers.Add("X-Correlation-ID", probeId);
                 if(_optionalHeader != null) {
                     var optionalHeaders = _optionalHeader
-                        .Split('\n')
-                        .Select(line => line.Split(':').Select(x => x.Trim()).ToArray())
+                        .Split(new [] {'\n'}, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(line => line
+                            .Split(new [] {':'}, 1, StringSplitOptions.RemoveEmptyEntries)
+                            .Select(x => x.Trim())
+                            .ToArray())
                         .Where(keyValuePair => keyValuePair.Length == 2)
                         .ToArray();
                     foreach (var optionalHeader in optionalHeaders)

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -31,7 +31,7 @@ namespace Seq.Input.HealthCheck
         readonly string _title;
         readonly string _targetUrl;
         readonly string _authenticationHeaderValue;
-        private readonly string _optionalHeader;
+        readonly string _optionalHeader;
         readonly JsonDataExtractor _extractor;
         readonly bool _bypassHttpCaching;
         readonly HttpClient _httpClient;
@@ -54,7 +54,7 @@ namespace Seq.Input.HealthCheck
             _bypassHttpCaching = bypassHttpCaching;
         }
 
-        private static void AddOrOverwriteHeader(HttpRequestMessage request, string attribute, string value)
+        static void AddOrOverwriteHeader(HttpRequestMessage request, string attribute, string value)
         {
             // opportunistic abort: header values cannot be empty (https://datatracker.ietf.org/doc/html/rfc7230#section-3.2)
             if (string.IsNullOrWhiteSpace(value))

--- a/src/Seq.Input.HealthCheck/Util/HeaderSettingFormat.cs
+++ b/src/Seq.Input.HealthCheck/Util/HeaderSettingFormat.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+namespace Seq.Input.HealthCheck.Util
+{
+    // adapted from: https://github.com/datalust/seq-app-httprequest/blob/e23b2328141352f5b4851c7502801f5bfe6511f7/src/Seq.App.HttpRequest/Settings/HeaderSettingFormat.cs
+    // changes to parse for C# 8.0 language level
+    static class HeaderSettingFormat
+    {
+        public static List<(string, string)> FromSettings(string authenticationHeader, string otherHeaders)
+        {
+            var headers = new List<(string, string)>();
+            
+            if (!string.IsNullOrWhiteSpace(authenticationHeader))
+                headers.Add(Parse(authenticationHeader));
+            
+            if (!string.IsNullOrWhiteSpace(otherHeaders))
+            {
+                var reader = new StringReader(otherHeaders);
+                var line = reader.ReadLine();
+                while (!string.IsNullOrWhiteSpace(line))
+                {
+                    headers.Add(Parse(line));
+                    line = reader.ReadLine();
+                }
+            }
+
+            return headers;
+        }
+
+        internal static (string, string) Parse(string header)
+        {
+            var components = header.Split(new[] { ':' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            if (components.Length != 2)
+            {
+                throw new ArgumentException($"The header must be specified in `Name: Value` format. (Affected line was '{header}')");
+            }
+
+            return (components[0].Trim(), components[1].Trim());
+        }
+    }
+}


### PR DESCRIPTION
This PR implements optional authentication headers. It follows the style of `Seq.App.HttpRequest`. I've omitted optional / additional headers for now.

The version number is not yet bumped, I didn't feel comfortable doing that, you know your versioning better.

I've tested it with a local instance and it works as expected.

Related Issue: #11 Authentication