### PR TITLE
Add jitter to delay the start of the first check

### DIFF
--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using Seq.Apps;
 using Seq.Input.HealthCheck.Data;
@@ -70,13 +71,6 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
     public int IntervalSeconds { get; set; } = 60;
 
     [SeqAppSetting(
-        DisplayName = "Jitter (seconds)",
-        IsOptional = true,
-        HelpText = "Adds a random amount of jitter to the running of the first check, to prevent all health checks " +
-                   "from occurring simultaneously; the default is 0.")]
-    public int JitterSeconds { get; set; } = 0;
-
-    [SeqAppSetting(
         DisplayName = "Data extraction expression",
         IsOptional = true,
         HelpText = "A Seq query language expression used to extract information from JSON responses. " +
@@ -94,10 +88,9 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
         if (!string.IsNullOrWhiteSpace(DataExtractionExpression))
             extractor = new JsonDataExtractor(DataExtractionExpression);
 
-        var random = new Random();
-
         var targetUrls = TargetUrl.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
-        foreach (var targetUrl in targetUrls)
+
+        foreach (var (targetUrl, ix) in targetUrls.Select((t, i) => (t, i)))
         {
             var healthCheck = new HttpHealthCheck(
                 _httpClient,
@@ -108,10 +101,14 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
                 BypassHttpCaching,
                 FollowRedirects);
 
+            var delayStart = targetUrls.Length <= 1
+                ? TimeSpan.Zero
+                : TimeSpan.FromSeconds(((IntervalSeconds * 1000.0) / targetUrls.Length) * ix);
+
             _healthCheckTasks.Add(new HealthCheckTask(
                 healthCheck,
                 TimeSpan.FromSeconds(IntervalSeconds),
-                JitterSeconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(random.Next(0, JitterSeconds * 1000)),
+                delayStart,
                 reporter,
                 Log));
         }

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -70,6 +70,13 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
     public int IntervalSeconds { get; set; } = 60;
 
     [SeqAppSetting(
+        DisplayName = "Jitter (seconds)",
+        IsOptional = true,
+        HelpText = "Adds a random amount of jitter to the running of the first check, to prevent all health checks " +
+                   "from occurring simultaneously; the default is 0.")]
+    public int JitterSeconds { get; set; } = 0;
+
+    [SeqAppSetting(
         DisplayName = "Data extraction expression",
         IsOptional = true,
         HelpText = "A Seq query language expression used to extract information from JSON responses. " +
@@ -87,6 +94,8 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
         if (!string.IsNullOrWhiteSpace(DataExtractionExpression))
             extractor = new JsonDataExtractor(DataExtractionExpression);
 
+        var random = new Random();
+
         var targetUrls = TargetUrl.Split(new[] {'\r', '\n'}, StringSplitOptions.RemoveEmptyEntries);
         foreach (var targetUrl in targetUrls)
         {
@@ -102,6 +111,7 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
             _healthCheckTasks.Add(new HealthCheckTask(
                 healthCheck,
                 TimeSpan.FromSeconds(IntervalSeconds),
+                TimeSpan.FromSeconds(JitterSeconds),
                 reporter,
                 Log));
         }

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -111,7 +111,7 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
             _healthCheckTasks.Add(new HealthCheckTask(
                 healthCheck,
                 TimeSpan.FromSeconds(IntervalSeconds),
-                TimeSpan.FromSeconds(JitterSeconds),
+                JitterSeconds == 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(random.Next(0, JitterSeconds * 1000)),
                 reporter,
                 Log));
         }

--- a/src/Seq.Input.HealthCheck/HealthCheckInput.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckInput.cs
@@ -103,7 +103,7 @@ public class HealthCheckInput : SeqApp, IPublishJson, IDisposable
 
             var delayStart = targetUrls.Length <= 1
                 ? TimeSpan.Zero
-                : TimeSpan.FromSeconds(((IntervalSeconds * 1000.0) / targetUrls.Length) * ix);
+                : TimeSpan.FromMilliseconds(((IntervalSeconds * 1000.0) / targetUrls.Length) * ix);
 
             _healthCheckTasks.Add(new HealthCheckTask(
                 healthCheck,

--- a/src/Seq.Input.HealthCheck/HealthCheckTask.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckTask.cs
@@ -42,7 +42,7 @@ class HealthCheckTask : IDisposable
     {
         try
         {
-            if (delayStart > TimeSpan.Zero) await Task.Delay((int) delayStart.TotalMilliseconds, cancel);
+            if (delayStart > TimeSpan.Zero) await Task.Delay(delayStart, cancel);
 
             while (!cancel.IsCancellationRequested)
             {

--- a/src/Seq.Input.HealthCheck/HealthCheckTask.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckTask.cs
@@ -24,23 +24,26 @@ class HealthCheckTask : IDisposable
     readonly CancellationTokenSource _cancel = new();
     readonly Task _healthCheckTask;
 
-    public HealthCheckTask(HttpHealthCheck healthCheck, TimeSpan interval, HealthCheckReporter reporter, ILogger diagnosticLog)
+    public HealthCheckTask(HttpHealthCheck healthCheck, TimeSpan interval, TimeSpan delayStart, HealthCheckReporter reporter, ILogger diagnosticLog)
     {
         if (healthCheck == null) throw new ArgumentNullException(nameof(healthCheck));
         if (reporter == null) throw new ArgumentNullException(nameof(reporter));
 
-        _healthCheckTask = Task.Run(() => Run(healthCheck, interval, reporter, diagnosticLog, _cancel.Token), _cancel.Token);
+        _healthCheckTask = Task.Run(() => Run(healthCheck, interval, delayStart, reporter, diagnosticLog, _cancel.Token), _cancel.Token);
     }
 
     static async Task Run(
         HttpHealthCheck healthCheck,
-        TimeSpan interval, 
-        HealthCheckReporter reporter, 
+        TimeSpan interval,
+        TimeSpan delayStart,
+        HealthCheckReporter reporter,
         ILogger diagnosticLog,
         CancellationToken cancel)
     {
         try
         {
+            if (delayStart > TimeSpan.Zero) await Task.Delay((int) delayStart.TotalMilliseconds, cancel);
+
             while (!cancel.IsCancellationRequested)
             {
                 var result = await healthCheck.CheckNow(cancel);


### PR DESCRIPTION
We've got a number of tenants, and we're finding we're receiving timeouts on checks due to the health checks causing (what we assume is) a rate limit on a dependent API that we check the connectivity to as part of our health check.

We want a delayed start "jitter" between the checks in a hope to prevent this from occurring.