### PR TITLE
Record health checks as spans (traces)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,6 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+
+.DS_Store
+

--- a/Build.ps1
+++ b/Build.ps1
@@ -18,11 +18,15 @@ $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch
 
 echo "build: Version suffix is $suffix"
 
-foreach ($src in ls src/*) {
+foreach ($src in Get-ChildItem src/*) {
     Push-Location $src
 
-    echo "build: Packaging project in $src"
+    echo "build: Packaging app project in $src"
 
+    if (Test-Path ./obj/publish) {
+        Remove-Item -Recurse -Force ./obj/publish
+    }
+    
     if ($suffix) {
         & dotnet publish -c Release -o ./obj/publish --version-suffix=$suffix
         & dotnet pack -c Release -o ..\..\artifacts --no-build --version-suffix=$suffix
@@ -30,18 +34,18 @@ foreach ($src in ls src/*) {
         & dotnet publish -c Release -o ./obj/publish
         & dotnet pack -c Release -o ..\..\artifacts --no-build
     }
-    if($LASTEXITCODE -ne 0) { exit 1 }    
+    if($LASTEXITCODE -ne 0) { throw "Build failed" }    
 
     Pop-Location
 }
 
-foreach ($test in ls test/*.Tests) {
+foreach ($test in Get-ChildItem test/*.Tests) {
     Push-Location $test
 
     echo "build: Testing project in $test"
 
     & dotnet test -c Release
-    if($LASTEXITCODE -ne 0) { exit 3 }
+    if($LASTEXITCODE -ne 0) { throw "Testing failed" }
 
     Pop-Location
 }

--- a/Run.ps1
+++ b/Run.ps1
@@ -1,0 +1,5 @@
+param (
+    [string] $targetUrl = 'https://example.com',
+    [int] $intervalSeconds = 5
+)
+seqcli app run -d ./src/Seq.Input.HealthCheck/obj/publish/ -p TargetUrl=$targetUrl -p IntervalSeconds=$intervalSeconds

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 skip_tags: true
 image: Visual Studio 2022
 build_script:
-- ps: ./Build.ps1
+- pwsh: ./Build.ps1
 test: off
 artifacts:
 - path: artifacts/Seq.Input.HealthCheck.*.nupkg

--- a/seq-input-healthcheck.sln
+++ b/seq-input-healthcheck.sln
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{7D1D14F7-D40
 		Build.ps1 = Build.ps1
 		LICENSE = LICENSE
 		README.md = README.md
+		Run.ps1 = Run.ps1
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{704915B0-6D95-4CF8-ACC2-5ED939A2913C}"

--- a/src/Seq.Input.HealthCheck/HealthCheckResult.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckResult.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics;
 using System.Globalization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -24,8 +25,11 @@ namespace Seq.Input.HealthCheck;
 
 class HealthCheckResult
 {
+    [JsonProperty("@st")]
+    public DateTime SpanStartTimestamp { get;  }
+    
     [JsonProperty("@t")]
-    public DateTime UtcTimestamp { get; }
+    public DateTime Timestamp { get; }
 
     [JsonProperty("@x", DefaultValueHandling = DefaultValueHandling.Ignore)]
     public string? Exception { get; }
@@ -38,7 +42,15 @@ class HealthCheckResult
     public string? Level { get; }
 
     [JsonProperty("@r")]
-    public string[] Renderings => new[] {Elapsed.ToString("0.000", CultureInfo.InvariantCulture)};
+    public string[] Renderings => [Elapsed.ToString("0.000", CultureInfo.InvariantCulture)];
+    
+    [JsonProperty("@tr")]
+    public string TraceId { get; }
+    
+    [JsonProperty("@sp")]
+    public string SpanId { get; }
+
+    [JsonProperty] public string Application { get; } = "Seq.Input.HealthCheck";
 
     public string HealthCheckTitle { get; }
     public string Method { get; }
@@ -48,11 +60,10 @@ class HealthCheckResult
     public int? StatusCode { get; }
     public string? ContentType { get; }
     public long? ContentLength { get; }
-    public string ProbeId { get; }
 
     /// <summary>
     /// If the probed URL differs from the target URL, e.g. due to cache-busting query string
-    /// parameters, this field will be set. Otherwise it can be assumed that the target URL was
+    /// parameters, this field will be set. Otherwise, it can be assumed that the target URL was
     /// used as-is.
     /// </summary>
     [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -80,12 +91,12 @@ class HealthCheckResult
     public JToken? Data { get; }
 
     public HealthCheckResult(
-        DateTime utcTimestamp,
+        DateTime spanStartTimestamp,
+        DateTime timestamp,
         string healthCheckTitle,
         string method,
         string targetUrl,
         string outcome,
-        string probeId,
         string? level,
         double elapsed,
         int? statusCode,
@@ -96,19 +107,22 @@ class HealthCheckResult
         JToken? data,
         string? probedUrl,
         int? redirectCount,
-        string? finalUrl)
+        string? finalUrl,
+        ActivityTraceId traceId,
+        ActivitySpanId spanId)
     {
-        if (utcTimestamp.Kind != DateTimeKind.Utc)
-            throw new ArgumentException("The timestamp must be UTC.", nameof(utcTimestamp));
+        if (spanStartTimestamp.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("The start timestamp must be UTC.", nameof(timestamp));
 
-        UtcTimestamp = utcTimestamp;
+        if (timestamp.Kind != DateTimeKind.Utc)
+            throw new ArgumentException("The timestamp must be UTC.", nameof(timestamp));
 
+        SpanStartTimestamp = spanStartTimestamp;
+        Timestamp = timestamp;
         HealthCheckTitle = healthCheckTitle ?? throw new ArgumentNullException(nameof(healthCheckTitle));
         Method = method ?? throw new ArgumentNullException(nameof(method));
         TargetUrl = targetUrl ?? throw new ArgumentNullException(nameof(targetUrl));
         Outcome = outcome ?? throw new ArgumentNullException(nameof(outcome));
-        ProbeId = probeId ?? throw new ArgumentNullException(nameof(probeId));
-
         Level = level;
         Elapsed = elapsed;
         StatusCode = statusCode;
@@ -120,5 +134,7 @@ class HealthCheckResult
         ProbedUrl = probedUrl;
         RedirectCount = redirectCount;
         FinalUrl = finalUrl;
+        TraceId = traceId.ToHexString();
+        SpanId = spanId.ToHexString();
     }
 }

--- a/src/Seq.Input.HealthCheck/HealthCheckResult.cs
+++ b/src/Seq.Input.HealthCheck/HealthCheckResult.cs
@@ -112,7 +112,7 @@ class HealthCheckResult
         ActivitySpanId spanId)
     {
         if (spanStartTimestamp.Kind != DateTimeKind.Utc)
-            throw new ArgumentException("The start timestamp must be UTC.", nameof(timestamp));
+            throw new ArgumentException("The start timestamp must be UTC.", nameof(spanStartTimestamp));
 
         if (timestamp.Kind != DateTimeKind.Utc)
             throw new ArgumentException("The timestamp must be UTC.", nameof(timestamp));

--- a/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheck.cs
@@ -39,7 +39,6 @@ class HttpHealthCheck
     readonly byte[] _buffer = new byte[2048];
 
     public const string ProbeIdParameterName = "__probe";
-    public const string CorrelationHeaderId = "X-Correlation-ID";
     public const int MaxRedirectCount = 10;
 
     static readonly UTF8Encoding ForgivingEncoding = new(false, false);
@@ -70,17 +69,17 @@ class HttpHealthCheck
         JToken? data = null;
         var redirectCount = 0;
 
-        var probeId = Nonce.Generate(12);
-        var probedUrl = _bypassHttpCaching ? UriHelper.AppendParameter(_targetUrl, ProbeIdParameterName, probeId) : _targetUrl;
+        var traceId = ActivityTraceId.CreateRandom();
+        var spanId = ActivitySpanId.CreateRandom();
+        var probedUrl = _bypassHttpCaching ? UriHelper.AppendParameter(_targetUrl, ProbeIdParameterName, traceId.ToString()) : _targetUrl;
             
         var finalUrl = probedUrl;
             
-        var utcTimestamp = DateTime.UtcNow;
         var sw = Stopwatch.StartNew();
 
         try
         {
-            (var response, finalUrl, redirectCount) = await SendRequest(probedUrl, probeId, cancel);
+            (var response, finalUrl, redirectCount) = await SendRequest(probedUrl, traceId, spanId, cancel);
 
             statusCode = (int) response.StatusCode;
             contentType = response.Content.Headers.ContentType?.ToString();
@@ -98,18 +97,23 @@ class HttpHealthCheck
         }
 
         sw.Stop();
+        var timestamp = DateTime.UtcNow;
+        
+        // Elapsed timing is more useful than precise clock times, so we use the stopwatch rather than collect
+        // a start time explicitly.
+        var startTimestamp = timestamp - sw.Elapsed;
 
         var level = outcome == OutcomeFailed ? "Error" :
             data == null && _extractor != null ? "Warning" :
             null;
 
         return new HealthCheckResult(
-            utcTimestamp,
+            startTimestamp,
+            timestamp,
             _title,
             "GET",
             _targetUrl,
             outcome,
-            probeId,
             level,
             sw.Elapsed.TotalMilliseconds,
             statusCode,
@@ -120,12 +124,17 @@ class HttpHealthCheck
             data,
             probedUrl == _targetUrl ? null : probedUrl,
             _shouldFollowRedirects ? redirectCount : null,
-            redirectCount > 0 ? finalUrl : null);
+            redirectCount > 0 ? finalUrl : null,
+            traceId,
+            spanId);
     }
 
-    void AddHeadersToRequest(HttpRequestMessage request, string probeId)
+    void AddHeadersToRequest(HttpRequestMessage request, ActivityTraceId traceId, ActivitySpanId spanId)
     {
-        request.Headers.Add(CorrelationHeaderId, probeId);
+        // The sampled bit (`-01`) is set because it communicates "the caller may have recorded trace data", which
+        // is the case.
+        request.Headers.Add("traceparent", $"00-{traceId}-{spanId}-01");
+
         foreach (var (name, value) in _headers)
         {
             // This will throw if a header is duplicated (better for the user to detect this configuration problem).
@@ -136,7 +145,7 @@ class HttpHealthCheck
             request.Headers.CacheControl = new CacheControlHeaderValue {NoStore = true};
     }
 
-    async Task<(HttpResponseMessage, string, int)> SendRequest(string requestUri, string correlationId, CancellationToken cancel)
+    async Task<(HttpResponseMessage, string, int)> SendRequest(string requestUri, ActivityTraceId traceId, ActivitySpanId spanId, CancellationToken cancel)
     {
         HttpResponseMessage response = null!;
         var totalRedirects = 0;
@@ -144,7 +153,7 @@ class HttpHealthCheck
         for (var i = 0; i <= MaxRedirectCount; i++)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-            AddHeadersToRequest(request, correlationId);
+            AddHeadersToRequest(request, traceId, spanId);
 
             response = await _httpClient.SendAsync(request, cancel);
             var statusCode = (int) response.StatusCode;

--- a/src/Seq.Input.HealthCheck/HttpHealthCheckClient.cs
+++ b/src/Seq.Input.HealthCheck/HttpHealthCheckClient.cs
@@ -20,7 +20,7 @@ public static class HttpHealthCheckClient
 {
     public static HttpClient Create()
     {
-        var handler = new HttpClientHandler { AllowAutoRedirect = false };
+        var handler = new SocketsHttpHandler { AllowAutoRedirect = false, ActivityHeadersPropagator = null };
         var httpClient = new HttpClient(handler);
         httpClient.DefaultRequestHeaders.Connection.Add("Close");
         return httpClient;

--- a/src/Seq.Input.HealthCheck/Seq.Input.HealthCheck.csproj
+++ b/src/Seq.Input.HealthCheck/Seq.Input.HealthCheck.csproj
@@ -15,6 +15,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,7 @@
   <ItemGroup>
     <None Include="../../asset/seq-input-healthcheck.png" Pack="true" Visible="false" PackagePath="" />
     <None Include="../../LICENSE" Pack="true" PackagePath="" />
+    <None Include="../../README.md" Pack="true" PackagePath="" />
     <None Include="./obj/publish/**/*" Exclude="./obj/publish/Seq.Input.HealthCheck.dll;./obj/publish/Seq.Apps.dll;./obj/publish/Serilog.dll" Pack="true" PackagePath="lib/$(TargetFramework)" />
   </ItemGroup>
   

--- a/test/Seq.Input.HealthCheck.Tests/Data/JsonDataExtractorTests.cs
+++ b/test/Seq.Input.HealthCheck.Tests/Data/JsonDataExtractorTests.cs
@@ -25,7 +25,7 @@ public class JsonDataExtractorTests
         var extractor = new JsonDataExtractor("Person");
         var value = extractor.ExtractData(new StringReader(json));
         var jo = Assert.IsType<JObject>(value);
-        var jv = (JValue)jo["Name"];
+        var jv = (JValue)jo["Name"]!;
         Assert.Equal("Nick", jv.Value);
     }
     

--- a/test/Seq.Input.HealthCheck.Tests/Seq.Input.HealthCheck.Tests.csproj
+++ b/test/Seq.Input.HealthCheck.Tests/Seq.Input.HealthCheck.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Today, `Seq.Input.HealthCheck` identifies its requests by logging a `ProbeId` property which it attaches to outbound requests in an `X-Correlation-Id` header.

This PR does a few related things to modernize the app:

 * Instead of `X-Correlation-Id`, the [W3C `traceparent` header](https://www.w3.org/TR/trace-context/#traceparent-header) is sent with outbound requests
 * Instead of `ProbeId`, this is recorded as `@TraceId` in the health check event; a corresponding `@SpanId` is recorded for the health check event itself
 * The duration taken by the health check is represented as span start and end times, in addition to the `Elapsed` property
 * An `Application` property is added to all events marking them as from `Seq.Input.HealthCheck`

The result is pretty great: you can now not only see how long the health check took, but if you're collecting traces from the checked application, how server-side and network latencies contribute to the total check time:

![image](https://github.com/user-attachments/assets/f339b640-17f0-4226-aab3-f11ce4b86bf4)

If the checked application did anything interesting to handle the health check, this will also be visible on the trace.

### Compatibility

The resulting span's `@EventType`, `@Message`, and `@MessageTemplate` properties in Seq will be unchanged - this should allow the spans to be detected as health check results by existing signals/queries/charts.

The `Elapsed` property is retained, even though it duplicates Seq's built-in `@Elapsed` property for spans, because the existing property is widely used in charts and alerts.

The `ProbeId` property is dropped, since although it's been around a long time, it's generally only examined manually.

If the health check is already configured to attache an `Application` property, this will override the newly-added one, so no change should be observed.

Finally, applications receiving the health checks may now generate additional trace data because of the sampled flag in the incoming `traceparent`. If the additional data is undesirable, the checked application can be triggered to suppress or sample it, or (in the case of applications exposed publicly), ignore incoming traceparent headers (which we'd recommend in most cases).